### PR TITLE
Feature/check bad rsync

### DIFF
--- a/isabl_cli/api.py
+++ b/isabl_cli/api.py
@@ -702,7 +702,15 @@ def _set_analysis_permissions(analysis):
             src = analysis.storage_url + "__tmp"
             shutil.move(analysis.storage_url, src)
             cmd = utils.get_rsync_command(src, analysis.storage_url, chmod="a-w")
-            subprocess.check_call(cmd, shell=True)
+            try:
+                subprocess.check_call(cmd, shell=True)
+            except subprocess.CalledProcessError:
+                try:
+                    version_stdout = subprocess.check_call(["rsync", "--version"], shell=True).split("\n")[0]
+                    utils.check_rsync_version(version_stdout)
+                except Exception as e:
+                    click.secho(f"Error running rsync and checking its version", fg="red")
+                    raise(e)
         else:
             subprocess.check_call(["chmod", "-R", "a-w", analysis.storage_url])
 

--- a/isabl_cli/commands.py
+++ b/isabl_cli/commands.py
@@ -83,7 +83,7 @@ def merge_individual_analyses(individual, application):  # pragma: no cover
 @click.command()
 @click.option("--force", help="Update previously patched results.", is_flag=True)
 @options.NULLABLE_FILTERS
-def process_finished(filters):
+def process_finished(filters, force):
     """Process and update finished analyses."""
     utils.check_admin()
     filters.update(status="FINISHED", fields="pk")

--- a/isabl_cli/commands.py
+++ b/isabl_cli/commands.py
@@ -96,7 +96,7 @@ def process_finished(filters):
         i = api.Analysis(i.pk)
 
         if i.status == "FINISHED":
-            if force or if tag in {j.name for j in i.tags}:
+            if force or tag in {j.name for j in i.tags}:
                 n_not_patched += 1
             else:
                 api.patch_instance("analyses", i.pk, tags=i.tags + [{"name": tag}])
@@ -113,8 +113,9 @@ def process_finished(filters):
                     raise Exception(patch_error)
     if n_not_patched:
         click.echo(
-            f"Successfully processed {n_patched} analyses, but skipped " +
-            f"{n_not_patched} analyses in use by other processes")
+            f"Successfully processed {n_patched} analyses, but skipped "
+            + f"{n_not_patched} analyses in use by other processes"
+        )
 
 
 @click.command()

--- a/isabl_cli/utils.py
+++ b/isabl_cli/utils.py
@@ -7,12 +7,14 @@ from pwd import getpwuid
 import getpass
 import json
 import os
+import re
 import sys
 import tarfile
 
 import analytics
 import click
 
+from packaging import version
 from isabl_cli.settings import system_settings
 
 
@@ -196,6 +198,13 @@ def get_rsync_command(src, dst, chmod="a-w"):
         f"find {src}/ -depth -type d -empty "
         r'-exec rmdir "{}" \;'
     )
+
+def check_rsync_version(version_stdout):
+    """check for outdated rsync lacking the --append-verify"""
+    version_string =  re.search(r'.*(?P<ver>\d\.\d\.\d).*', version_stdout).group("ver")
+    major_version = version.parse(version_string).major
+    if major_version != 3:
+        raise ValueError("Please upgrade your version of rsync!")
 
 
 def get_tree_size(path, follow_symlinks=False):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -145,3 +145,10 @@ def test_called_from():
     assert "a_function" in a_function()
     assert "test_called_from" in a_function()
     assert "pytest_pyfunc_call" in a_function()
+
+def test_rsync_version_checking():
+    incompatible_version_string = "rsync  version 2.6.9  protocol version 29"
+    with pytest.raises(ValueError):
+        utils.check_rsync_version(incompatible_version_string)
+    compatible_version_string = "rsync  version 3.2.7  protocol version 31"
+    assert utils.check_rsync_version(compatible_version_string) is None


### PR DESCRIPTION
Isabl relies on a current version of rsync, but Macs ship with an old one.  this adds a check for this situation to let the user know their rsync version might be the problem.


- [ ] 🐛 &nbsp; Bug fix
- [X] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [X] ✅ &nbsp; I have added tests to cover my changes
