### PR TITLE
Fix/issue33

### DIFF
--- a/isabl_cli/commands.py
+++ b/isabl_cli/commands.py
@@ -96,7 +96,7 @@ def process_finished(filters, force):
         i = api.Analysis(i.pk)
 
         if i.status == "FINISHED":
-            if force or tag in {j.name for j in i.tags}:
+            if not force and tag in {j.name for j in i.tags}:
                 n_not_patched += 1
             else:
                 api.patch_instance("analyses", i.pk, tags=i.tags + [{"name": tag}])

--- a/isabl_cli/commands.py
+++ b/isabl_cli/commands.py
@@ -83,7 +83,7 @@ def merge_individual_analyses(individual, application):  # pragma: no cover
 @click.command()
 @click.option("--force", help="Update previously patched results.", is_flag=True)
 @options.NULLABLE_FILTERS
-def process_finished(filters):
+def process_finished(filters, force):
     """Process and update finished analyses."""
     utils.check_admin()
     filters.update(status="FINISHED", fields="pk")

--- a/isabl_cli/commands.py
+++ b/isabl_cli/commands.py
@@ -96,7 +96,7 @@ def process_finished(filters):
         i = api.Analysis(i.pk)
 
         if i.status == "FINISHED":
-            if force or if tag in {j.name for j in i.tags}:
+            if force or tag in {j.name for j in i.tags}:
                 n_not_patched += 1
             else:
                 api.patch_instance("analyses", i.pk, tags=i.tags + [{"name": tag}])
@@ -113,8 +113,9 @@ def process_finished(filters):
                     raise Exception(patch_error)
     if n_not_patched:
         click.echo(
-            f"Successfully processed {n_patched} analyses, but skipped " +
-            f"{n_not_patched} analyses in use by other processes")
+            f"Successfully processed {n_patched} analyses, but skipped "
+            + f"{n_not_patched} analyses in use by other processes"
+        )
 
 
 @click.command()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -320,7 +320,7 @@ def test_force_process_finished_tags(tmpdir):
     )
     runner = CliRunner()
     args = ["-fi", "pk", analysis["pk"], "--force"]
-    result =  runner.invoke(commands.process_finished, args, catch_exceptions=False)
+    result = runner.invoke(commands.process_finished, args, catch_exceptions=True)
     print(result.output)
     analysis = api.get_instance("analyses", analysis["pk"])
     assert analysis["status"] == "SUCCEEDED"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -284,3 +284,43 @@ def test_run_web_signals():
         result_key="analysis_result_key",
         application_name=str(MockApplication),
     )
+
+
+def test_process_finished_tags(tmpdir):
+    # check that a tagged analysis does NOT get processed to FINISHED
+    analysis = api.create_instance(
+        "analyses",
+        project_level_analysis=factories.ProjectFactory(),
+        storage_url=tmpdir.strpath,
+        status="FINISHED",
+        **factories.AnalysisFactory(ran_by=None, tags=[{"name":"PROCESSING FINISHED"}]),
+    )
+    runner = CliRunner()
+    args = ["-fi", "pk", analysis["pk"]]
+    runner.invoke(commands.process_finished, args, catch_exceptions=False)
+    analysis = api.get_instance("analyses", analysis["pk"])
+    assert analysis["status"] == "FINISHED"
+
+    # strip the tags, check that is DOES get processed
+    api.patch_instance("analyses", analysis.pk,
+                       **factories.AnalysisFactory(ran_by=None, tags=[]))
+    runner.invoke(commands.process_finished, args, catch_exceptions=False)
+    analysis = api.get_instance("analyses", analysis["pk"])
+    assert analysis["status"] == "SUCCEEDED"
+
+
+def test_force_process_finished_tags(tmpdir):
+    # check that a tagged analysis does get processed to FINISHED when forced
+    analysis = api.create_instance(
+        "analyses",
+        project_level_analysis=factories.ProjectFactory(),
+        storage_url=tmpdir.strpath,
+        status="FINISHED",
+        **factories.AnalysisFactory(ran_by=None, tags=[{"name":"PROCESSING FINISHED"}]),
+    )
+    runner = CliRunner()
+    args = ["-fi", "pk", analysis["pk"], "--force"]
+    result =  runner.invoke(commands.process_finished, args, catch_exceptions=False)
+    print(result.output)
+    analysis = api.get_instance("analyses", analysis["pk"])
+    assert analysis["status"] == "SUCCEEDED"


### PR DESCRIPTION
This addresses issue #33 -- adds a `--force` option to process-finished to address issues where analyses get left with tags preventing them from getting finished.  The command now warns if not all FINISHED analyses could be moved to SUCCEEDED.
- [X] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [X] ✅ &nbsp; I have added tests to cover my changes
