### PR TITLE
Feature: allow app-specific runtime overrides

### DIFF
--- a/isabl_cli/batch_systems/lsf.py
+++ b/isabl_cli/batch_systems/lsf.py
@@ -42,10 +42,8 @@ def submit_lsf(app, command_tuples):  # pragma: no cover
             exit_cmd = app.get_patch_status_command(i["pk"], "FAILED")
             commands.append((app.get_command_script_path(i), exit_cmd))
             if hasattr(app, "EXTRA_ARGS_OVERRIDE"):
-                print(app.EXTRA_ARGS_OVERRIDE)
                 extra_args_overrides.append(app.EXTRA_ARGS_OVERRIDE)
             else:
-                print("No extra args!")
                 extra_args_overrides.append(submit_configuration.get("extra_args", ""))
             keys = [j["pk"] for k in i["targets"] for j in k["projects"]]
             projects.update(keys)

--- a/isabl_cli/batch_systems/sge.py
+++ b/isabl_cli/batch_systems/sge.py
@@ -55,7 +55,7 @@ def submit_sge(app, command_tuples):  # pragma: no cover
     # execute analyses on a methods basis
     for methods, cmd_tuples in groups.items():
         click.echo(f"Submitting {len(cmd_tuples)} ({', '.join(methods)}) jobs.")
-        commands, analyses, projects = [], [], set()
+        commands, analyses, projects, extra_args_overrides = [], [], set(), []
         requirements = ""
 
         # ignore command in tuple and use script instead
@@ -63,6 +63,10 @@ def submit_sge(app, command_tuples):  # pragma: no cover
             analyses.append(i)
             exit_cmd = app.get_patch_status_command(i["pk"], "FAILED")
             commands.append((app.get_command_script_path(i), exit_cmd))
+            if hasattr(app, "EXTRA_ARGS_OVERRIDE"):
+                extra_args_overrides.append(app.EXTRA_ARGS_OVERRIDE)
+            else:
+                extra_args_overrides.append(submit_configuration.get("extra_args", ""))
             keys = [j["pk"] for k in i["targets"] for j in k["projects"]]
             projects.update(keys)
 

--- a/isabl_cli/batch_systems/sge.py
+++ b/isabl_cli/batch_systems/sge.py
@@ -54,6 +54,7 @@ def submit_sge(app, command_tuples):  # pragma: no cover
 
     # execute analyses on a methods basis
     for methods, cmd_tuples in groups.items():
+        submit_configuration = system_settings.SUBMIT_CONFIGURATION
         click.echo(f"Submitting {len(cmd_tuples)} ({', '.join(methods)}) jobs.")
         commands, analyses, projects, extra_args_overrides = [], [], set(), []
         requirements = ""
@@ -80,12 +81,11 @@ def submit_sge(app, command_tuples):  # pragma: no cover
 
         try:
             api.patch_analyses_status(analyses, "SUBMITTED")
-            submit_configuration = system_settings.SUBMIT_CONFIGURATION
-            for i in api.chunks(commands, 10000):
+            for i, j in zip(api.chunks(commands, 10000),  api.chunks(extra_args_overrides, 10000)):
                 submit_sge_array(
                     commands=i,
                     requirements=requirements or "",
-                    extra_args=submit_configuration.get("extra_args", ""),
+                    extra_args=j[0],
                     throttle_by=submit_configuration.get("throttle_by", 50),
                     jobname=(
                         f"application: {app} | "

--- a/isabl_cli/batch_systems/slurm.py
+++ b/isabl_cli/batch_systems/slurm.py
@@ -32,7 +32,7 @@ def submit_slurm(app, command_tuples):  # pragma: no cover
     # execute analyses on a methods basis
     for methods, cmd_tuples in groups.items():
         click.echo(f"Submitting {len(cmd_tuples)} ({', '.join(methods)}) jobs.")
-        commands, analyses, projects = [], [], set()
+        commands, analyses, projects, extra_args_overrides = [], [], set(), []
         requirements = ""
 
         # ignore command in tuple and use script instead
@@ -40,6 +40,10 @@ def submit_slurm(app, command_tuples):  # pragma: no cover
             analyses.append(i)
             exit_cmd = app.get_patch_status_command(i["pk"], "FAILED")
             commands.append((app.get_command_script_path(i), exit_cmd))
+            if hasattr(app, "EXTRA_ARGS_OVERRIDE"):
+                extra_args_overrides.append(app.EXTRA_ARGS_OVERRIDE)
+            else:
+                extra_args_overrides.append(submit_configuration.get("extra_args", ""))
             keys = [j["pk"] for k in i["targets"] for j in k["projects"]]
             projects.update(keys)
 


### PR DESCRIPTION
We have some apps that take 5 minutes and some that take days.  Currently, we have to set the batch submitter `EXTRA_ARGS` to the maximum time across  any of the installed apps.  This PR allows a OVERRIDE_EXTRA_ARGS class attribute to be passed to the batch submitter for app-specific batch parameters.  Our use-case is runtime, but this could allow some apps to be submitted to a gpu queue, etc.


- [ ] 🐛 &nbsp; Bug fix
- [X] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes

I don't have a test setup with a non-local batch system set up, but this seems to work on our production setup. Any insight would be appreciated -- I don't know how this would work with project- or  individual-level analyses.

