### PR TITLE
add experimental --pretty and --all flags for get-metadata

### DIFF
--- a/isabl_cli/commands.py
+++ b/isabl_cli/commands.py
@@ -161,10 +161,12 @@ def patch_status(key, status):
 @options.NULLABLE_IDENTIFIERS
 @click.option("--json", "json_", help="Print as JSON", is_flag=True)
 @click.option("--fx", "use_fx", help="Visualize json with fx", is_flag=True)
-def get_metadata(identifiers, endpoint, field, filters, no_headers, json_, use_fx):
+@click.option("--pretty", "pretty", help="prettified output", is_flag=True)
+@click.option("--all", "output_all", help="include all fields in the tabular output", is_flag=True)
+def get_metadata(identifiers, endpoint, field, filters, no_headers, json_, use_fx, output_all, pretty):
     """Retrieve metadata for multiple instances."""
-    if not field and not (json_ or use_fx):  # pragma: no cover
-        raise click.UsageError("Pass --field or use --json/--fx")
+    if not field and not (json_ or use_fx or output_all):  # pragma: no cover
+        raise click.UsageError("Pass --field or use --json/--fx/--all")
 
     if use_fx and not shutil.which("fx"):  # pragma: no cover
         raise click.UsageError("fx is not installed")
@@ -181,6 +183,8 @@ def get_metadata(identifiers, endpoint, field, filters, no_headers, json_, use_f
             OrderedDict([(".".join(j), utils.traverse_dict(i, j)) for j in field])
             for i in instances
         ]
+    elif output_all:
+        field = [[i] for i in instances[0].__dict__.keys()]
 
     if json_:
         click.echo(json.dumps(instances, sort_keys=True, indent=4))
@@ -193,7 +197,10 @@ def get_metadata(identifiers, endpoint, field, filters, no_headers, json_, use_f
     else:
         result = [] if no_headers else ["\t".join(".".join(i) for i in field)]
         result += ["\t".join(map(str, i.values())) for i in instances]
-        click.echo("\n".join(result).expandtabs(30))
+        if pretty:
+            click.echo("\n".join(result).expandtabs(30))
+        else:
+            click.echo("\n".join(result))
 
 
 @click.command()


### PR DESCRIPTION
This addresses #38.  Not to sneak in an additional feature, but I figured this is a experimental PR and added something I was missing: an `--all` flag for those of us that are bad at remembering the field names.


This changes the default behavior for get-metadata to outputing machine readable TSV, and enabling pretty printing with a `--pretty` flag.  

The `--all` flag retrieves all the first-level fields for a given metadata query.  Previously I was having to either consult the API docs or run a`--json/fx` output to find the field names I was looking for.  

Taken together, this makes it easy to do things like:

`isabl get-metadata analyses --all | grep FAILED | cut -f 1`


as opposed to previously:

```
# either the following to find the fields of interest or consulting the docs
isabl get-metadata analyses --json
# and then pull the fields, fix the bad spacing, and extract relevant info
isabl get-metadata analyses --field pk  --field status | sed 's/ \+/\t/g'  | cut -f 1
```

`cut 1 ` is a suboptimal example cause it would have worked regardless of uneven spacing but still :) 


- [ ] 🐛 &nbsp; Bug fix
- [X] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [X] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
