### PR TITLE
🐛 enforce_user_on_analysis_restart

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -941,12 +941,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
                     continue
 
                 elif restart and i.ran_by != system_settings.api_username:
-                    invalid_tuples.append(
-                        (
-                            i,
-                            "Can't restart: started by different user. Consider --force",
-                        )
-                    )
+                    invalid_tuples.append((i, "Can't restart: started by different user. Consider --force"))
                     continue
 
                 try:
@@ -1202,9 +1197,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
 
         try:
             assert self.application.settings.get(client_id) == settings
-            click.secho(
-                f"\tNo changes detected, skipping patch.\n", err=True, fg="yellow"
-            )
+            click.secho(f"\tNo changes detected, skipping patch.\n", err=True, fg="yellow")
         except AssertionError:
             try:
                 api.patch_instance(
@@ -1225,9 +1218,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
 
                 click.secho("\tSuccessfully patched settings.\n", fg="green")
             except TypeError as error:  # pragma: no cover
-                click.secho(
-                    f"\tPatched failed with error: {error}.\n", err=True, fg="red"
-                )
+                click.secho(f"\tPatched failed with error: {error}.\n", err=True, fg="red")
 
         # create or update project level application
         if self.has_project_auto_merge:
@@ -1582,9 +1573,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
                 current_tuple = tuples_map[individual.pk]
 
                 # make sure we only have one analysis per individual
-                assert (
-                    individual.pk not in existing
-                ), f"Multiple analyses for {individual}"
+                assert individual.pk not in existing, f"Multiple analyses for {individual}"
                 existing[individual.pk] = i
 
                 # patch analysis if tuples differ

--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -936,6 +936,10 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
                 ):
                     skipped_tuples.append((i, i["status"]))
                     continue
+                
+                elif restart and i.ran_by != system_settings.api_username:
+                    skipped_tuples.append((i, i["status"]))   
+                    continue
 
                 try:
                     inputs = i.pop(

--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -884,9 +884,11 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
                 self._patch_analysis(i)
 
         # run analyses
-        run_tuples, skipped_tuples = self.run_analyses(
+        run_tuples, skipped_tuples, invalid_run_tuples = self.run_analyses(
             analyses=analyses, commit=commit, force=force, restart=restart, local=local
         )
+
+        invalid_tuples.extend(invalid_run_tuples)
 
         if verbose:
             self.echo_run_summary(run_tuples, skipped_tuples, invalid_tuples)
@@ -907,6 +909,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
             list: tuple of
         """
         skipped_tuples = []
+        invalid_tuples = []
         command_tuples = []
         submit_analyses = (
             submit_local
@@ -938,7 +941,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
                     continue
                 
                 elif restart and i.ran_by != system_settings.api_username:
-                    skipped_tuples.append((i, i["status"]))   
+                    invalid_tuples.append((i, i["Can't --restart as it was started by different user. Consider --force"]))  
                     continue
 
                 try:
@@ -957,6 +960,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
         self.send_analytics(
             command_tuples=command_tuples,
             skipped_tuples=skipped_tuples,
+            invalid_tuples=invalid_tuples,
             commit=commit,
             force=force,
             restart=restart,
@@ -969,10 +973,10 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
         else:
             run_tuples = [(i, self._staged_message) for i, _ in command_tuples]
 
-        return run_tuples, skipped_tuples
+        return run_tuples, skipped_tuples, invalid_tuples
 
     def send_analytics(
-        self, command_tuples, skipped_tuples, commit, force, restart, submitter
+        self, command_tuples, skipped_tuples, invalid_tuples, commit, force, restart, submitter
     ):
         """Send analytics event of analyses ran from cli."""
         analyses_tuples = []

--- a/isabl_cli/factories.py
+++ b/isabl_cli/factories.py
@@ -11,6 +11,10 @@ class BaseFactory(factory.DictFactory):
     tags = [{"name": "tag 1"}, {"name": "tag 2"}]
 
 
+class UserFactory(BaseFactory):
+    username = fuzzy.FuzzyText(length=6, chars=string.ascii_letters)
+
+
 class ProjectFactory(BaseFactory):
     analyst = factory.Sequence(lambda n: f"analyst-{n}@test.com")
     coordinator = factory.Sequence(lambda n: f"coordinator-{n}@test.com")

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,7 @@ python_files =
 
 addopts =
     -rxEfsw
-    --strict
+    --strict-markers
     --doctest-modules
     --doctest-glob=\*.rst
     --tb=short

--- a/setup.json
+++ b/setup.json
@@ -33,7 +33,7 @@
       "pluggy>=0.7.1",
       "pydocstyle>=2.1.1",
       "pylint>=1.8.1",
-      "pytest>=3.7.4",
+      "pytest>=4.5",
       "pytest-cov>=2.5.1",
       "pytest-env>=0.6.2",
       "pytest-sugar>=0.9.1",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,13 +16,11 @@ from isabl_cli.settings import get_application_settings
 
 
 class NonSequencingApplication(AbstractApplication):
-
     NAME = str(uuid.uuid4())
     VERSION = "STILL_TESTING"
 
 
 class ExperimentsFromDefaulCLIApplication(AbstractApplication):
-
     NAME = str(uuid.uuid4())
     VERSION = "STILL_TESTING"
     ASSEMBLY = "GRCh4000"
@@ -40,12 +38,11 @@ class ExperimentsFromDefaulCLIApplication(AbstractApplication):
     def validate_experiments(self, targets, references):
         assert not any("raise validation error" in target.notes for target in targets)
 
-    def get_command(*_): # pylint: disable=no-method-argument
+    def get_command(*_):  # pylint: disable=no-method-argument
         return ""
 
 
 class MockApplication(AbstractApplication):
-
     NAME = str(uuid.uuid4())
     VERSION = "STILL_TESTING"
     ASSEMBLY = "GRCh4000"
@@ -137,7 +134,6 @@ class MockApplication(AbstractApplication):
 
 
 class UniquePerIndividualApplication(AbstractApplication):
-
     NAME = "UNIQUE_PER_INDIVIDUAL"
     VERSION = "STILL_TESTING"
     ASSEMBLY = "GRCh4000"
@@ -167,7 +163,6 @@ class UniquePerIndividualApplication(AbstractApplication):
 
 
 class UniquePerIndividualProtectResultsFalse(UniquePerIndividualApplication):
-
     NAME = "UNIQUE_PER_INDIVIDUAL_NO_PROTECT"
     application_protect_results = False
 
@@ -424,14 +419,11 @@ def test_engine(tmpdir):
     assert f"{experiments[0].system_id} has no registered bedfile" in str(error.value)
 
     # test that get results work as expected
-    assert (
-        application.get_results(
-            result_key="analysis_result_key",
-            experiment=target,
-            application_key=application.primary_key,
-        )
-        == [(1, ran_analyses[1][0].pk)]
-    )
+    assert application.get_results(
+        result_key="analysis_result_key",
+        experiment=target,
+        application_key=application.primary_key,
+    ) == [(1, ran_analyses[1][0].pk)]
 
     # check assertion error is raised when an invalid result is searched for
     with pytest.raises(AssertionError) as error:
@@ -998,7 +990,7 @@ def test_get_dependencies():
     assert not analysis.analyses
 
 
-def test_ran_by_user(tmpdir):
+def test_ran_by_user(tmpdir, capsys):
     user = api.create_instance("users", **factories.UserFactory())
 
     experiment = api.create_instance("experiments", **factories.ExperimentFactory())
@@ -1016,5 +1008,8 @@ def test_ran_by_user(tmpdir):
         [([experiment], [])], commit=True, restart=True
     )
     assert len(ran_analyses) == 0
-    assert len(skipped_analyses) > 0
-    assert len(invalid_analyses) == 0
+    assert len(skipped_analyses) == 0
+    assert len(invalid_analyses) == 1
+
+    captured = capsys.readouterr()
+    assert "Can't restart: started by different user. Consider --force" in captured.out

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -996,3 +996,25 @@ def test_get_dependencies():
     analysis, status = ran_analyses[0]
     assert status == "SUCCEEDED"
     assert not analysis.analyses
+
+
+def test_ran_by_user(tmpdir):
+    user = api.create_instance("users", **factories.UserFactory())
+
+    experiment = api.create_instance("experiments", **factories.ExperimentFactory())
+
+    application = MockApplication()
+    analysis = api.create_instance(
+        "analyses",
+        storage_url=tmpdir.strpath,
+        status="FAILED",
+        ran_by=user.username,
+        application=application.application,
+        targets=[experiment],
+    )
+    ran_analyses, skipped_analyses, invalid_analyses = application.run(
+        [([experiment], [])], commit=True, restart=True
+    )
+    assert len(ran_analyses) == 0
+    assert len(skipped_analyses) > 0
+    assert len(invalid_analyses) == 0


### PR DESCRIPTION
In reference to issue #35, this change ensures that the user re-starting an analysis is the same user that initially started it. 

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
