### PR TITLE
🔧 fix to use latest version result if multiple apps

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -1116,7 +1116,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
             # Match app by name, and optionally by version
             if dependency.get("app_name"):
                 result_args["application_name"] = dependency.get("app_name")
-                if "version" in dependency:
+                if "app_version" in dependency:
                     result_args["application_version"] = dependency.get("app_version")
             else:
                 # Match app by primary key

--- a/isabl_cli/utils.py
+++ b/isabl_cli/utils.py
@@ -71,7 +71,10 @@ def get_results(
             if i.application.pk == application_key:
                 experiment_results.append(i)
         elif application_name:
-            if application_version:
+            if (
+                application_version
+                and application_version != "latest"
+            ):
                 if (
                     i.application.name == application_name
                     and i.application.version == application_version
@@ -113,8 +116,8 @@ def get_results(
             f"{i.pk}({i.application.name} {i.application.version}) is {i.status}"
         )
 
-    # If more than 1 result and version is `any`, use latest.
-    if len(results) > 2 and application_version == "any":
+    # Return latest if more than 1 result and version is `latest`.
+    if len(results) > 2 and application_version == "latest":
         results = sorted(results, key=lambda x: x[1], reverse=True)[:1]
 
     return results
@@ -135,7 +138,8 @@ def get_result(*args, **kwargs):
     app_name = kwargs.get("application_name") or kwargs.get("application_key")
     results = get_results(*args, **kwargs)
     assert results, f"No results found for application: {app_name}"
-    assert len(results) == 1, f"Multiple results returned {results}"
+    if kwargs.get("application_version") != "latest": 
+        assert len(results) == 1, f"Multiple results returned {results}"
     result, key = results[0]
     return result, key
 


### PR DESCRIPTION
This PR improves #22, where a desired feature was to run an app with the latest dependency when 2 or more versions of the same app are available. 

## Example:
We have a sample with 2 versions of an application: `STRELKA` has `v1.0` and v2.0`

```
pk  name  version
-------------------
1   MUTECT   v1.0
2   STRELKA  v1.0
3   STRELKA  v2.0
```

if we want to run Annotation that depends on Mutect and Strelka:
```python
dependencies_results = [
    {
        "app_name": "STRELKA", 
        "result": "snvs", 
        "name": "strelka_snvs"
    },
    {
        "app_name": "MUTECT",
        "result": "snvs", 
        "name": "strelka_snvs"
    },
]
```

### Before
We get an invalid message saying:
```
RUNNING 1 TUPLES FOR ANNOTATION 1.0.0 GRCH37
-----------------------------------------
IDENTIFIER          PROJECTS            TARGETS             REFERENCES          MESSAGE
INVALID             100 (TD)            DEMO_H100001_T01_01_TD01                 DEMO_H100001_N01_01_TD01                 INVALID Multiple results returned for STRELKA: [('<path>', 10002), ('<path>', 10003)] 
```
Where 10002 is the analysis of `STRELKA (v1.0)` and 10003 is the analysis of `STRELKA (v2.0)`.

### After
Using `latest` version in the dependencies:
```python
dependencies_results = [
    {
        "app_name": "STRELKA", 
        "app_version: "latest",
        "result": "snvs", 
        "name": "strelka_snvs"
    },
    {
        "app_name": "MUTECT",
        "app_version: "latest",
        "result": "snvs", 
        "name": "strelka_snvs"
    },
]
```
We can run the app that will use the result of the latest version of `STRELKA` (`v2.0`)
```
RUNNING 1 TUPLES FOR ANNOTATION 1.0.0 GRCH37
-------------------------------------------------------
IDENTIFIER          PROJECTS            TARGETS             REFERENCES          MESSAGE
INVALID             100 (TD)            DEMO_H100001_T01_01_TD01                 DEMO_H100001_N01_01_TD01                 READY FOR SUBMISSION <path> 
```
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
