### PR TITLE
🔧 validate species only if app has assembly

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -1779,7 +1779,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
         msg = []
 
         for i in experiments:
-            if self.SPECIES and i["sample"]["individual"]["species"] != self.SPECIES:
+            if self.ASSEMBLY and i["sample"]["individual"]["species"] != self.SPECIES:
                 msg.append(f'{i["system_id"]} species not supported')
 
         assert not msg, "\n".join(msg)

--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -1779,7 +1779,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
         msg = []
 
         for i in experiments:
-            if i["sample"]["individual"]["species"] != self.SPECIES:
+            if self.SPECIES and i["sample"]["individual"]["species"] != self.SPECIES:
                 msg.append(f'{i["system_id"]} species not supported')
 
         assert not msg, "\n".join(msg)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -627,7 +627,7 @@ def test_validate_dna_rna_only():
 
 
 def test_validate_species():
-    application = AbstractApplication()
+    application = MockApplication()
     targets = [{"sample": {"individual": {"species": "MOUSE"}}, "system_id": "FOO"}]
 
     with pytest.raises(AssertionError) as error:


### PR DESCRIPTION
From #23, @nickp60 made me realize that validating `species` should only be done if app has `ASSEMBLY`. 
As we want to support non-NGS applications, it makes sense to allow having `SPECIES` and `ASSEMBLY` optional, as they might not be relevant on those cases.

- [x] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [x] ✅ &nbsp; I have added tests to cover my changes
