### PR TITLE
🐛 use `/bin/bash` in local submission

### DIFF
--- a/isabl_cli/batch_systems/local.py
+++ b/isabl_cli/batch_systems/local.py
@@ -31,6 +31,7 @@ def submit_local(app, command_tuples):
                         stdout=stdout,
                         stderr=stderr,
                         shell=True,
+                        executable="/bin/bash"
                     )
 
                 except subprocess.CalledProcessError:


### PR DESCRIPTION
Right now, when running apps locally (with `--local`). Some of the isabl command scripts syntax fails, because `subprocess.check_call` is submitting the commands with `/bin/sh`. Adding the param `executable="/bin/bash"` fixes the issue.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
