### PR TITLE
🔧 allow `extra_args` for every slurm exit and clean cmds

### DIFF
--- a/isabl_cli/batch_systems/slurm.py
+++ b/isabl_cli/batch_systems/slurm.py
@@ -123,7 +123,7 @@ def submit_slurm_array(
                 # important when the scheduler kills the head job
                 dependency = "${SLURM_ARRAY_JOB_ID}_${SLURM_ARRAY_TASK_ID}"
                 afternotok = (
-                    f"sbatch --depend=afternotok:{dependency} --kill-on-invalid-dep yes "
+                    f"sbatch {extra_args} --depend=afternotok:{dependency} --kill-on-invalid-dep yes "
                     f'-o {join(rundir, "head_job.exit")} -J "EXIT: {dependency}" '
                     f"<< EOF\n#!/bin/bash\n{exit_command}\nEOF\n"
                 )
@@ -155,7 +155,7 @@ def submit_slurm_array(
     jobid = subprocess.check_output(cmd, shell=True).decode("utf-8").strip()
 
     cmd = (
-        f"sbatch -J 'CLEAN: {jobname}' {wait} --kill-on-invalid-dep yes "
+        f"sbatch {extra_args} -J 'CLEAN: {jobname}' {wait} --kill-on-invalid-dep yes "
         f"-o /dev/null -e /dev/null --depend=afterany:{jobid} --parsable {root}/clean.sh"
     )
 

--- a/isabl_cli/settings.py
+++ b/isabl_cli/settings.py
@@ -33,6 +33,7 @@ _DEFAULTS = {
     "BASE_STORAGE_DIRECTORY": join(expanduser("~"), "isabl_storage"),
     "FASTQ_READ_SUFFIX": "",
     "ADMIN_USER": getpass.getuser(),
+    "CLIENT_NAME": None,
     "TIME_ZONE": "America/New_York",
     "INSTALLED_APPLICATIONS": [],
     "CUSTOM_COMMANDS": [],


### PR DESCRIPTION
Allow to add `extra_args` to every slurm submission job: main, exit and clean.

- [ ] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [x] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
