### PR TITLE
🔧 use /bin/bash in local submission

### DIFF
--- a/isabl_cli/batch_systems/local.py
+++ b/isabl_cli/batch_systems/local.py
@@ -31,6 +31,7 @@ def submit_local(app, command_tuples):
                         stdout=stdout,
                         stderr=stderr,
                         shell=True,
+                        executable="/bin/bash"
                     )
 
                 except subprocess.CalledProcessError:


### PR DESCRIPTION
When using local executor, using bash is needed to support proper isabl command syntax `{ command && command_if_succeeded || command_if_failed }`

- [ ] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [X] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
