### PR TITLE
⚡️ support pattern result matching by walking analyses outdirs

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -1194,6 +1194,18 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
 
         return analyses, inputs
 
+    def _get_analysis_results_from_patterns(self, analysis, specification):
+        """Get first matching file, if "pattern" is in result specification."""
+        results = {}
+        for name, result_specification in specification.items():
+            pattern = result_specification.get("pattern")
+            exclude = result_specification.get("exclude")
+            if pattern:
+                results[name] = utils.first_matching_file(
+                    analysis.storage_url, pattern, exclude
+                )
+        return results
+
     def _get_analysis_results(self, analysis, created=False):
         """Get results dictionary and append head job script, logs and error files."""
         results = {
@@ -1215,6 +1227,9 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
             specification = self.application_results
             get_results = self.get_analysis_results
 
+        results.update(
+            self._get_analysis_results_from_patterns(analysis, specification)
+        )
         results.update(get_results(analysis))
 
         for i in specification:

--- a/isabl_cli/data.py
+++ b/isabl_cli/data.py
@@ -147,7 +147,7 @@ def trigger_analyses_merge(analysis):
             ("Skipping " if pending else "Submitting ")
             + ("individual " if "species" in instance else "project ")
             + f"merge for {instance} and application {application}",
-            fg="green" if pending else "yellow",
+            fg="yellow" if pending else "green",
         )
 
     if application.has_project_auto_merge:

--- a/isabl_cli/utils.py
+++ b/isabl_cli/utils.py
@@ -318,8 +318,7 @@ def send_analytics(command):  # noqa
 
 def first_matching_file(directory, pattern, exclude=None):
     """
-    Recursively search within a dicrectory for the first file that matches the pattern.
-
+    Recursively search within a directory for the first file that matches the pattern.
     Args:
         directory (str): the directory to search within.
         pattern (str): a glob pattern (e.g., '*.txt') to match filenames.

--- a/isabl_cli/utils.py
+++ b/isabl_cli/utils.py
@@ -333,7 +333,7 @@ def first_matching_file(directory, pattern, exclude=None):
         FileNotFoundError: If no matching file is found.
     """
     root_path = Path(directory)
-    if not root_path.is_dir():
+    if not root_path.is_dir(): # pragma: no cover
         raise NotADirectoryError(f"{directory} is not a valid directory.")
 
     matching_files = (
@@ -343,5 +343,5 @@ def first_matching_file(directory, pattern, exclude=None):
 
     try:
         return str(next(matching_files))
-    except StopIteration:
+    except StopIteration: # pragma: no cover
         raise FileNotFoundError(f"No file matching pattern '{pattern}' found in '{directory}'")

--- a/isabl_cli/utils.py
+++ b/isabl_cli/utils.py
@@ -3,6 +3,7 @@
 from functools import update_wrapper
 from getpass import getuser
 from os import stat
+from pathlib import Path
 from pwd import getpwuid
 import getpass
 import json
@@ -313,3 +314,34 @@ def send_analytics(command):  # noqa
         )
 
     return update_wrapper(wrapper, command)
+
+
+def first_matching_file(directory, pattern, exclude=None):
+    """
+    Recursively search within a dicrectory for the first file that matches the pattern.
+
+    Args:
+        directory (str): the directory to search within.
+        pattern (str): a glob pattern (e.g., '*.txt') to match filenames.
+        exclude (str, optional): files containing this substring will be skipped.
+
+    Returns:
+        str: the path to the first matching file as a string.
+
+    Raises:
+        NotADirectoryError: If `directory` is not a valid directory.
+        FileNotFoundError: If no matching file is found.
+    """
+    root_path = Path(directory)
+    if not root_path.is_dir():
+        raise NotADirectoryError(f"{directory} is not a valid directory.")
+
+    matching_files = (
+        file for file in root_path.rglob(pattern)
+        if not (exclude and exclude in file.name)
+    )
+
+    try:
+        return str(next(matching_files))
+    except StopIteration:
+        raise FileNotFoundError(f"No file matching pattern '{pattern}' found in '{directory}'")

--- a/tests/test-with-compose.sh
+++ b/tests/test-with-compose.sh
@@ -1,3 +1,14 @@
+# parse arguments
+SKIP_BUILD=false
+for arg in "$@"; do
+  case $arg in
+    --skip-build)
+    SKIP_BUILD=true
+    shift
+    ;;
+  esac
+done
+
 # get path to demo directory
 if [ "$SHELL" = "zsh" ]; then
    TEST_DIR="$( cd "$(dirname ${(%):-%N})" ; pwd -P )"
@@ -15,14 +26,22 @@ echo "CLI directory set to: $CLI_DIR"
 ISABL_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH:-master}}
 echo "ISABL_BRANCH set to $ISABL_BRANCH given travis branch: $TRAVIS_BRANCH $TRAVIS_PULL_REQUEST_BRANCH"
 
-# clone api from github
-rm -rf $API_DIR && git clone https://github.com/papaemmelab/isabl_api.git $API_DIR
-cd $API_DIR && (git checkout $ISABL_BRANCH || true) && docker-compose build && docker-compose up -d
-
-# give some time to API to start and test Isabl CLI
-echo "Giving 30 seconds to API to get started..."
+# reset environment variables
+unset ISABL_CLIENT_ID
+unset ISABL_API_URL
 export ISABL_CLIENT_ID=test-cli-client
-sleep 30 && cd $CLI_DIR && pytest -vs tests/ --cov=isabl_cli || (
+
+if [ "$SKIP_BUILD" = false ]; then
+   # clone api from github
+   rm -rf $API_DIR && git clone https://github.com/papaemmelab/isabl_api.git $API_DIR
+   cd $API_DIR && (git checkout $ISABL_BRANCH || true) && docker-compose build && docker-compose up -d
+
+   # give some time to API to start and test Isabl CLI
+   echo "Giving 30 seconds to API to get started..."
+   sleep 30
+fi
+
+cd $CLI_DIR && pytest -vs tests/ --cov=isabl_cli || (
    # print django logs if tests fail
    cd $API_DIR && docker-compose logs django && exit 1
 )

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -94,7 +94,7 @@ def test_commands(tmpdir):
             ([api.create_instance("experiments", **experiment_b)], []),
         ],
         commit=True,
-        project_results=["project_result_key"],
+        project_results=["project_result_file"],
     )[0]
 
     args = ["--app-results", analysis.application.pk]


### PR DESCRIPTION
Related with issue: 
- #70 

## Changes

Adding the optional fields `pattern` (and `exclude`) to find matching file result in the outdirs directory by walking it recursively. 

```python
class MyNiceApp(isabl_cli.AbstractApplication):
    NAME = "MY_NICE_APP"
    VERSION = "0.1-beta"
    ...
    application_results = {
        "predicted_result": {
            "description": "predicted result",
            "verbose_name": "predicted result",
            "frontend_type": "text-file",
            "pattern": "predicted_result_*.txt",
            "exclude": "predicted_result_tmp.txt",
        },
        "nice_report": {
            "description": "interactive report",
            "verbose_name": "nice report",
            "frontend_type": "html",
            "pattern": "nice_report.html",
        },
    }
```
This avoids the need to define a method to `get_analysis_results` like the one below to match a file within the nested results, that for most apps is repeated boilerplate:

```python
...

    def get_analysis_results(self, analysis):
        outdir = analysis.storage_url
        predicted_result = (list(glob(join(outdir, "results", "predicted_result_*.txt"))) or [])[0]
        nice_report = join(outdir, "results", "reports", "nice_report.html")
        return { 
            "predicted_result": predicted_result, 
            "nice_report": nice_report 
        }
```

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] 🐛 &nbsp; Bug fix
- [X] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [X] ✅ &nbsp; I have added tests to cover my changes
