### PR TITLE
add method to allow custom logic execution at runtime

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -197,6 +197,14 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
         """Possible values are FINISHED and IN_PROGRESS."""
         return "FINISHED"
 
+    def update_analysis_at_runtime(self, analysis, inputs):  # pylint: disable=W0613
+        """Define custom logic to be executed at runtime
+        This can be used to update analysis objects's custom fields with values
+        only available during job execution, such as logging the inputs used
+        """
+        return
+
+
     def validate_settings(self, settings):
         """
         Validate settings.
@@ -995,6 +1003,7 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
                     )
 
                     command = self.get_command(i, inputs, self.settings)
+                    self.update_analysis_at_runtime(i, inputs)
                     command_tuples.append((i, command))
                     self.write_command_script(i, command)
                 except self.skip_exceptions as error:  # pragma: no cover


### PR DESCRIPTION
Hi Isabl team! We've run into the need to modify some analyses custom_fields at the actual runtime of the application, so this PR adds an optional method that gets executed after `get_command()` but before the jobs are actually submitted.  Our specific use case is logging the input dictionary (which we discussed in [Slack here](https://mskcc.slack.com/archives/G01FEKLL0C9/p1721740406852299)), which we added as a custom field to the Analysis entity.  We didn't want to put this in get_analysis_results() for two reasons: the `inputs` aren't available at the time, and there is a chance that the apps get_dependencies logic would return a different set of files at runtime vs whenever the `patch-results` command is executed.  


- [ ] 🐛 &nbsp; Bug fix
- [X] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
