### PR TITLE
Reconfigured `AbstractApplication` to use `abc.ABC`

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -591,7 +591,7 @@ class AbstractApplication(abc.ABC):  # pylint: disable=too-many-public-methods
     @cached_property
     def individual_level_auto_merge_application(self):
         """Get or create an individual level application database object."""
-        if not self.is_overridden(self.merge_individual_analyses.__name__):
+        if not self.is_overridden(self.merge_individual_analyses):
             raise NotImplementedError(
                 "No logic implemented to merge analyses for an individual..."
             )
@@ -615,7 +615,7 @@ class AbstractApplication(abc.ABC):  # pylint: disable=too-many-public-methods
     @cached_property
     def project_level_auto_merge_application(self):
         """Get or create a project level application database object."""
-        if not self.is_overridden(self.merge_project_analyses.__name__):
+        if not self.is_overridden(self.merge_project_analyses):
             raise NotImplementedError(
                 "No logic implemented to merge analyses for a project..."
             )
@@ -644,7 +644,7 @@ class AbstractApplication(abc.ABC):  # pylint: disable=too-many-public-methods
     @property
     def has_project_auto_merge(self):
         """Return True if project level auto merge logic is defined."""
-        if not self.is_overridden(self.merge_project_analyses.__name__):
+        if not self.is_overridden(self.merge_project_analyses):
             raise NotImplementedError(
                 "No logic implemented to merge analyses for a project..."
             )
@@ -652,7 +652,7 @@ class AbstractApplication(abc.ABC):  # pylint: disable=too-many-public-methods
     @property
     def has_individual_auto_merge(self):
         """Return True if individual level auto merge logic is defined.""" 
-        return self.is_overridden(self.merge_individual_analyses.__name__)
+        return self.is_overridden(self.merge_individual_analyses)
 
     @property
     def _application_results(self):
@@ -1243,11 +1243,12 @@ class AbstractApplication(abc.ABC):  # pylint: disable=too-many-public-methods
     # APPLICATION UTILS
     # -----------------
 
-    @staticmethod
-    def is_overridden(self, method_name):
-        base_method = getattr(AbstractApplication, method_name, None)
-        instance_method = getattr(self, method_name, None)
-        return instance_method is not None and instance_method.__func__ is not base_method
+    def is_overridden(self, method):
+        """Checks if a method of the base class was overridden."""
+        method_name = method.__name__
+        base_method = getattr(self.__class__.__bases__[0], method_name, None)
+        return method.__func__ is not base_method
+
 
     @staticmethod
     def get_result(*args, **kwargs):  # pragma: no cover

--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -1246,7 +1246,7 @@ class AbstractApplication(abc.ABC):  # pylint: disable=too-many-public-methods
     def is_overridden(self, method):
         """Checks if a method of the base class was overridden."""
         method_name = method.__name__
-        base_method = getattr(self.__class__.__bases__[0], method_name, None)
+        base_method = getattr(AbstractApplication, method_name, None)
         return method.__func__ is not base_method
 
 


### PR DESCRIPTION
Canonically `@abc.abstractmethod` is used to designate methods that are mandatory for subclasses to implement - otherwise those classes fail at instantiation. This behavior is only active if the class inherits from `abc.ABC` or analogons.
However, `@abc.abstractmethod` can also be used to simply add the `__isabstractmethod__` property to a class or instance method which is how it was used in `AbstractApplication`.

I have reconfigured the `AbstractApplication` to inherit from `abc.ABC` and have replaced the logic that `@abc.abstractmethod` was used for previously with `is_overridden`. 

There is some discussion to be had about the exact implementation of `is_overridden`. Currently it is hardcoded to check whether a method of specifically `AbstractApplication` was overridden, as opposed to the base class of the instance `self.__class__.__bases__[0]`.

- [ ] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [x] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
