### PR TITLE
add delete_instance to __init__.py

### DIFF
--- a/isabl_cli/__init__.py
+++ b/isabl_cli/__init__.py
@@ -8,6 +8,7 @@ from isabl_cli.api import Analysis
 from isabl_cli.api import Assembly
 from isabl_cli.api import Experiment
 from isabl_cli.api import create_instance
+from isabl_cli.api import delete_instance
 from isabl_cli.api import get_analyses
 from isabl_cli.api import get_experiments
 from isabl_cli.api import get_instance


### PR DESCRIPTION
The [docs](https://docs.isabl.io/retrieve-data#create-delete-and-modify-instances) mention `ii.delete_instance` but that doesn't work currently bc it's not being imported in `__init__.py`. This PR fixes this.

- [x] 🔧 &nbsp; Code refactor
- [x] 📘 &nbsp; I have updated the documentation accordingly

