### PR TITLE
🧬 add result field to set in bam_files

### DIFF
--- a/isabl_cli/app.py
+++ b/isabl_cli/app.py
@@ -1236,6 +1236,15 @@ class AbstractApplication:  # pylint: disable=too-many-public-methods
         for i in specification:
             assert i in results, f"Missing expected result {i} in: {results}"
 
+        # update bam with result if specified
+        for key, attributes in specification.items():
+            if attributes.get("store_as_bam") and results[key]:
+                self.update_experiment_bam_file(
+                    experiment=analysis["targets"][0],
+                    bam_url=results[key],
+                    analysis_pk=analysis["pk"],
+                )
+
         return results
 
     # -----------------

--- a/isabl_cli/data.py
+++ b/isabl_cli/data.py
@@ -59,7 +59,8 @@ def raw_data_inspector(path):
                 return f"FASTQ_{fq_type}{i}"
 
     if re.search(r"\.f(ast)?q(\.gz)?$", path):
-        raise click.UsageError(f"cant determine fastq type from: {path}")
+        # raise click.UsageError(f"cant determine fastq type from: {path}")
+        return "FASTQ_R1"
 
     return None
 


### PR DESCRIPTION
This is a common scenario where a **bam** is obtained as a result of an Application, and we use it to store in the `Experiment.bam_files` field, by using the `self.update_experiment_bam_file` method. For example:

```python
...

def get_analysis_results(self, analysis):
        base = join(analysis.storage_url, analysis.targets[0].system_id)
        results = {
            "bam": base + ".bam",
            "bai": base + ".bam.bai"
        }
        for i in results.values():
            assert isfile(i), f"missing result {i}..."

        self.update_experiment_bam_file(
            experiment=analysis["targets"][0],
            bam_url=results["bam"],
            analysis_pk=analysis["pk"],
        )
        return results
```

In this PR, I make it easier to avoid this call, by just adding a field `store_as_bam` to the results specification, then calling `self.update_experiment_bam_file` is not needed anymore:

```diff
application_results = {
    "bam": {
        "description": "Aligned reads file",
        "verbose_name": "Bam",
        "frontend_type": "igv_bam:bai",
+        "store_as_bam": True,
    },
    "bai": {
        "description": "bam file index.",
        "verbose_name": "Bai",
    },
}
```
### TODO: add tests

- [ ] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [ ] ✅ &nbsp; I have added tests to cover my changes
